### PR TITLE
changing function plugin version and removing useless configuration

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -53,7 +53,7 @@
                 <plugin>
                     <groupId>com.microsoft.azure</groupId>
                     <artifactId>azure-functions-maven-plugin</artifactId>
-                    <version>1.0.0</version>
+                    <version>1.0.0-beta-1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -101,22 +101,6 @@
                                         <include>host.json</include>
                                         <include>local.settings.json</include>
                                     </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-bin</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <overwrite>true</overwrite>
-                            <outputDirectory>${stagingDirectory}/bin</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${project.basedir}/bin</directory>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
Since the function extensions will automatically installed in the bin folder. There is no need to use maven resources plugin to copy-paste them