### PR TITLE
fix a bug that copying the function runtime into lib

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -124,7 +124,7 @@
                         <overWriteSnapshots>false</overWriteSnapshots>
                         <overWriteIfNewer>true</overWriteIfNewer>
                         <includeScope>runtime</includeScope>
-                        <excludeArtifactIds>com.microsoft.azure.azure-functions-java-core</excludeArtifactIds>
+                        <excludeArtifactIds>azure-functions-java-core</excludeArtifactIds>
                     </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Since it's ArtifactIds, the group Id should not be involved