### PR TITLE
Rename template function to fit java naming conventions

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/src/main/java/Function.java
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/src/main/java/Function.java
@@ -14,7 +14,7 @@ public class Function {
      * 2. curl {your host}/api/HttpTrigger-Java?name=HTTP%20Query
      */
     @FunctionName("HttpTrigger-Java")
-    public HttpResponseMessage HttpTriggerJava(
+    public HttpResponseMessage run(
             @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
             final ExecutionContext context) {
         context.getLogger().info("Java HTTP trigger processed a request.");

--- a/azure-functions-archetype/src/main/resources/archetype-resources/src/test/java/FunctionTest.java
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/src/test/java/FunctionTest.java
@@ -49,7 +49,7 @@ public class FunctionTest {
         doReturn(Logger.getGlobal()).when(context).getLogger();
 
         // Invoke
-        final HttpResponseMessage ret = new Function().HttpTriggerJava(req, context);
+        final HttpResponseMessage ret = new Function().run(req, context);
 
         // Verify
         assertEquals(ret.getStatus(), HttpStatus.OK);


### PR DESCRIPTION
Rename template function to fit java naming conventions and keep consistent with c# archetypes