### PR TITLE
Add FUNCTIONS_WORKER_RUNTIME: java into application settings 

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -95,6 +95,10 @@
                             <name>FUNCTIONS_EXTENSION_VERSION</name>
                             <value>beta</value>
                         </property>
+                        <property>
+                            <name>FUNCTIONS_WORKER_RUNTIME</name>
+                            <value>java</value>
+                        </property>
                     </appSettings>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Add FUNCTIONS_WORKER_RUNTIME: java into the application settings for Azure Functions Runtime breaking change. For issue #58 