### PR TITLE
Remove App Setting FUNCTIONS_WORKER_RUNTIME as maven plugin will default set it to java

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -133,10 +133,6 @@
                             <name>FUNCTIONS_EXTENSION_VERSION</name>
                             <value>~2</value>
                         </property>
-                        <property>
-                            <name>FUNCTIONS_WORKER_RUNTIME</name>
-                            <value>java</value>
-                        </property>
                     </appSettings>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Remove App Setting FUNCTIONS_WORKER_RUNTIME as maven plugin will default set it to `java`, for issue #71 