### PR TITLE
Remove App Setting FUNCTIONS_WORKER_RUNTIME

### DIFF
--- a/azure-functions-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -147,10 +147,6 @@
                             <name>FUNCTIONS_EXTENSION_VERSION</name>
                             <value>~2</value>
                         </property>
-                        <property>
-                            <name>FUNCTIONS_WORKER_RUNTIME</name>
-                            <value>java</value>
-                        </property>
                     </appSettings>
                 </configuration>
                 <executions>

--- a/azure-functions-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-kotlin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.31</kotlin.version>
         <functions.version>1.3.0</functions.version>
-        <functions.plugin.version>1.3.2</functions.plugin.version>
+        <functions.plugin.version>1.3.3</functions.plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>


### PR DESCRIPTION
Remove App Setting FUNCTIONS_WORKER_RUNTIME as maven plugin will default set it to `java`, for issue #71 