### PR TITLE
Change the default HTTP trigger name to HttpExample

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/src/main/java/Function.java
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/src/main/java/Function.java
@@ -9,15 +9,13 @@ import com.microsoft.azure.functions.*;
  */
 public class Function {
     /**
-     * This function listens at endpoint "/api/HttpTrigger-Java". Two ways to invoke it using "curl" command in bash:
-     * 1. curl -d "HTTP Body" {your host}/api/HttpTrigger-Java&code={your function key}
-     * 2. curl "{your host}/api/HttpTrigger-Java?name=HTTP%20Query&code={your function key}"
-     * Function Key is not needed when running locally, it is used to invoke function deployed to Azure.
-     * More details: https://aka.ms/functions_authorization_keys
+     * This function listens at endpoint "/api/HttpExample". Two ways to invoke it using "curl" command in bash:
+     * 1. curl -d "HTTP Body" {your host}/api/HttpExample
+     * 2. curl "{your host}/api/HttpExample?name=HTTP%20Query"
      */
-    @FunctionName("HttpTrigger-Java")
+    @FunctionName("HttpExample")
     public HttpResponseMessage run(
-            @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<Optional<String>> request,
+            @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
             final ExecutionContext context) {
         context.getLogger().info("Java HTTP trigger processed a request.");
 


### PR DESCRIPTION
@pragnagopa and @kulkarnisonia16 this PR updates the HTTP triggered function name to align Java with the other quickstarts and lets us add a Java pivot in the existing quickstarts. It also switches the default to ANONYMOUS auth, which UX testing has shown to be more successful in quickstarts, and we now use in the others.