### PR TITLE
Bump extension bundle version in host.json to V2

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/host.json
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/host.json
@@ -2,6 +2,6 @@
   "version": "2.0",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[1.*, 2.0.0)"
+    "version": "[2.*, 3.0.0)"
   } 
 }


### PR DESCRIPTION
Bump extension bundle version in `host.json` to v2, fixes https://github.com/microsoft/azure-maven-archetypes/issues/181