### PR TITLE
Fix unused private field in scaffolded tests

### DIFF
--- a/azure-functions-archetype/src/main/resources/archetype-resources/src/test/java/HttpResponseMessageMock.java
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/src/test/java/HttpResponseMessageMock.java
@@ -29,7 +29,7 @@ public class HttpResponseMessageMock implements HttpResponseMessage {
 
     @Override
     public int getStatusCode() {
-        return httpStatusCode;
+        return this.httpStatusCode;
     }
 
     @Override
@@ -44,19 +44,16 @@ public class HttpResponseMessageMock implements HttpResponseMessage {
 
     public static class HttpResponseMessageBuilderMock implements HttpResponseMessage.Builder {
         private Object body;
-        private int httpStatusCode;
         private Map<String, String> headers = new HashMap<>();
         private HttpStatusType httpStatus;
 
         public Builder status(HttpStatus status) {
-            this.httpStatusCode = status.value();
             this.httpStatus = status;
             return this;
         }
 
         @Override
         public Builder status(HttpStatusType httpStatusType) {
-            this.httpStatusCode = httpStatusType.value();
             this.httpStatus = httpStatusType;
             return this;
         }

--- a/azure-functions-kotlin-archetype/src/main/resources/archetype-resources/src/test/kotlin/HttpResponseMessageMock.kt
+++ b/azure-functions-kotlin-archetype/src/main/resources/archetype-resources/src/test/kotlin/HttpResponseMessageMock.kt
@@ -31,18 +31,15 @@ class HttpResponseMessageMock(private val httpStatus: HttpStatusType, private va
 
     class HttpResponseMessageBuilderMock : HttpResponseMessage.Builder {
         private var body: Any? = null
-        private var httpStatusCode: Int = 0
         private val headers: MutableMap<String, String>? = null
         private var httpStatus: HttpStatusType? = null
 
         fun status(status: HttpStatus): HttpResponseMessage.Builder {
-            this.httpStatusCode = status.value()
             this.httpStatus = status
             return this
         }
 
         override fun status(httpStatusType: HttpStatusType): HttpResponseMessage.Builder {
-            this.httpStatusCode = httpStatusType.value()
             this.httpStatus = httpStatusType
             return this
         }


### PR DESCRIPTION
in the generated HttpResponseMessageMock classes, there is an ["UnusedPrivateField" lint warning](https://javadoc.io/static/org.aspectj/aspectjtools/1.7.4/org/aspectj/org/eclipse/jdt/core/compiler/IProblem.html#UnusedPrivateField) due to an httpStatusCode; this PR removes this variable and fixes the warning