### PR TITLE
Update Java Azure Functions Runtime OS and Java Version Template Defaults

### DIFF
--- a/azure-functions-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/azure-functions-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -37,7 +37,7 @@
         </requiredProperty>
 
         <requiredProperty key="javaVersion">
-            <defaultValue>17</defaultValue>
+            <defaultValue>21</defaultValue>
         </requiredProperty>
 
         <requiredProperty key="trigger">

--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,7 @@
 #else
         <java.version>${javaVersion}</java.version>
 #end
-        <azure.functions.maven.plugin.version>1.37.0</azure.functions.maven.plugin.version>
+        <azure.functions.maven.plugin.version>1.38.0</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
 #if(${appName}=="$(artifactId)-$(timestamp)")
         <functionAppName>${artifactId.toLowerCase()}-${package.getClass().forName("java.time.LocalDateTime").getMethod("now").invoke(null).format($package.Class.forName("java.time.format.DateTimeFormatter").getMethod("ofPattern", $package.Class).invoke(null, "yyyyMMddHHmmssSSS"))}</functionAppName>

--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -179,8 +179,9 @@
                         <serverId></serverId>
                         <registryUrl></registryUrl>
 #else
-                        <!-- runtime os, could be windows, linux or docker-->
-                        <os>windows</os>
+                        <!-- runtime os, could be windows, linux (default) or docker-->
+                        <!-- <os>linux</os> -->
+                        <!-- runtime Java version, could be 8, 11, 17, 21 (default) -->
                         <javaVersion>${javaVersion}</javaVersion>
 #end
                     </runtime>


### PR DESCRIPTION
This pull request updates the Azure Functions archetype to align with the latest Java version and Azure Functions Maven plugin version, while also improving configuration flexibility. The key changes include updating the default Java version, upgrading the Maven plugin version, and clarifying runtime configuration options.

### Updates to Java version and Maven plugin:

* [`azure-functions-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml`](diffhunk://#diff-423a2fab373e91438b024319a4b279757532198f91e05af857f6b9ca50a99116L40-R40): Updated the default Java version from 17 to 21 to support the latest Java release.
* [`azure-functions-archetype/src/main/resources/archetype-resources/pom.xml`](diffhunk://#diff-83e28a1d87a4d41a1fdbf952b8c0436dd04e1fbe61ddc004f0c505631532b883L19-R19): Upgraded the Azure Functions Maven plugin version from `1.37.0` to `1.38.0` to include the latest features and fixes.

### Improvements to runtime configuration:

* [`azure-functions-archetype/src/main/resources/archetype-resources/pom.xml`](diffhunk://#diff-83e28a1d87a4d41a1fdbf952b8c0436dd04e1fbe61ddc004f0c505631532b883L182-R184): Enhanced runtime configuration comments to clarify supported OS and Java version options. Added a commented-out example for specifying Linux as the runtime OS and highlighted Java 21 as the default runtime version.