### PR TITLE
Upgrade azure.functions.maven.plugin.version to 1.39.0

### DIFF
--- a/azure-functions-archetype/pom.xml
+++ b/azure-functions-archetype/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-archetype</artifactId>
-    <version>1.64</version>
+    <version>1.65</version>
     <packaging>jar</packaging>
 
     <name>Maven Archetype for Azure Functions</name>

--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -16,7 +16,7 @@
 #else
         <java.version>${javaVersion}</java.version>
 #end
-        <azure.functions.maven.plugin.version>1.38.0</azure.functions.maven.plugin.version>
+        <azure.functions.maven.plugin.version>1.39.0</azure.functions.maven.plugin.version>
         <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
 #if(${appName}=="$(artifactId)-$(timestamp)")
         <functionAppName>${artifactId.toLowerCase()}-${package.getClass().forName("java.time.LocalDateTime").getMethod("now").invoke(null).format($package.Class.forName("java.time.format.DateTimeFormatter").getMethod("ofPattern", $package.Class).invoke(null, "yyyyMMddHHmmssSSS"))}</functionAppName>


### PR DESCRIPTION
This pull request updates the version of the Azure Functions Maven plugin used in the archetype resource configuration. This ensures that new projects generated from the archetype will use the latest plugin version, which may include important bug fixes and features.

* Dependency version update:
  * Bumped the `azure.functions.maven.plugin.version` from `1.38.0` to `1.39.0` in `azure-functions-archetype/src/main/resources/archetype-resources/pom.xml`.