### PR TITLE
Add McpToolTrigger Support

### DIFF
--- a/azure-functions-archetype/README.md
+++ b/azure-functions-archetype/README.md
@@ -56,7 +56,7 @@ Parameter Name | Default Value | Description
 `javaVersion` | `17` | The the function host java version as well as the project compile level, supported values are `8`, `11`, `17` or `21` (Linux only).
 `docker` | `false` | The whether to enable docker support in your function project.
 `trigger` | `HttpTrigger` | Specify the trigger type of Azure Function, supported values are `HttpTrigger`, `BlobTrigger`, `QueueTrigger`, `TimerTrigger`, `EventGridTrigger`, `EventHubTrigger`, `CosmosDBTrigger`, `ServiceBusQueueTrigger`, `ServiceBusTopicTrigger`, `RabbitMQTrigger`, `KafkaTrigger`, `DurableFunctions`, `SqlOutputBinding`, `SqlInputBinding`, `SqlTrigger`, `DaprPublishOutputBinding`, `DaprServiceInvocationTrigger`,
-, `DaprTopicTrigger`, `AssistantSkillTrigger`, `AssistantCreate`, `AssistantQuery`, `AssistantPost`, `EmbeddingsInput`, `EmbeddingsStoreOutput`, `SemanticSearch`, `TextCompletion`
+, `DaprTopicTrigger`, `AssistantSkillTrigger`, `AssistantCreate`, `AssistantQuery`, `AssistantPost`, `EmbeddingsInput`, `EmbeddingsStoreOutput`, `SemanticSearch`, `TextCompletion`, `McpToolTrigger`
 
 ## System Requirements
 Azure Functions Core Tools | Azure CLI | Java SE | Maven

--- a/azure-functions-archetype/pom.xml
+++ b/azure-functions-archetype/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.microsoft.azure</groupId>
     <artifactId>azure-functions-archetype</artifactId>
-    <version>1.65</version>
+    <version>1.66</version>
     <packaging>jar</packaging>
 
     <name>Maven Archetype for Azure Functions</name>

--- a/azure-functions-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/azure-functions-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -45,7 +45,8 @@ def templateMap = [
         "EmbeddingsInput"               : "-Dfunctions.template=EmbeddingsInput -Dname=\"<name>\" -Dmodel=\"<model>\" -DmaxChunkLength=\"<maxChunkLength>\" -DmaxOverlap=\"<maxOverlap>\" -Dinput=\"<input>\" -DinputType=\"<inputType>\"",
         "EmbeddingsStoreOutput"         : "-Dfunctions.template=EmbeddingsStoreOutput -Dname=\"<name>\" -Dmodel=\"<model>\" -DmaxChunkLength=\"<maxChunkLength>\" -DmaxOverlap=\"<maxOverlap>\" -Dinput=\"<input>\" -DinputType=\"<inputType>\" -DconnectionName=\"<connectionName>\" -Dcollection=\"<collection>\"",
         "SemanticSearch"                : "-Dfunctions.template=SemanticSearch -Dname=\"<name>\" -DconnectionName=\"<connectionName>\" -Dcollection=\"<collection>\" -Dquery=\"<query>\" -DembeddingsModel=\"<embeddingsModel>\" -DchatModel=\"<chatModel>\" -DsystemPrompt=\"<systemPrompt>\" -DmaxKnowledgeLength=\"<maxKnowledgeLength>\"",
-        "TextCompletion"                : "-Dfunctions.template=TextCompletion -Dname=\"<name>\" -Dprompt=\"<prompt>\" -Dmodel=\"<model>\" -Dtemperature=\"<temperature>\" -DtopP=\"<topP>\" -DmaxTokens=\"<maxTokens>\""
+        "TextCompletion"                : "-Dfunctions.template=TextCompletion -Dname=\"<name>\" -Dprompt=\"<prompt>\" -Dmodel=\"<model>\" -Dtemperature=\"<temperature>\" -DtopP=\"<topP>\" -DmaxTokens=\"<maxTokens>\"",
+        "McpToolTrigger"                : "-Dfunctions.template=McpToolTrigger -DtoolName=\"<toolName>\" -DtoolDescription=\"<toolDescription>\""
 ]
 def triggerParameter = templateMap.keySet().stream()
         .filter({ key -> key.equalsIgnoreCase(trigger) || (key.lastIndexOf("Trigger") > 0 && key.substring(0, key.lastIndexOf("Trigger")).equalsIgnoreCase(trigger)) }).findFirst()

--- a/azure-functions-archetype/src/main/resources/archetype-resources/host.json
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/host.json
@@ -13,6 +13,11 @@
     "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
     "version": "[4.*, 5.0.0)"
   }
+#if(${trigger.toLowerCase()}=="mcptooltrigger")
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.29.0, 5.0.0)"
+  }
 #else
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",

--- a/azure-functions-archetype/src/main/resources/archetype-resources/host.json
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/host.json
@@ -13,7 +13,7 @@
     "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
     "version": "[4.*, 5.0.0)"
   }
-#if(${trigger.toLowerCase()}=="mcptooltrigger")
+#elseif(${trigger.toLowerCase()}=="mcptooltrigger")
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.29.0, 5.0.0)"

--- a/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/azure-functions-archetype/src/main/resources/archetype-resources/pom.xml
@@ -16,8 +16,8 @@
 #else
         <java.version>${javaVersion}</java.version>
 #end
-        <azure.functions.maven.plugin.version>1.39.0</azure.functions.maven.plugin.version>
-        <azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
+        <azure.functions.maven.plugin.version>1.40.0</azure.functions.maven.plugin.version>
+        <azure.functions.java.library.version>3.2.2</azure.functions.java.library.version>
 #if(${appName}=="$(artifactId)-$(timestamp)")
         <functionAppName>${artifactId.toLowerCase()}-${package.getClass().forName("java.time.LocalDateTime").getMethod("now").invoke(null).format($package.Class.forName("java.time.format.DateTimeFormatter").getMethod("ofPattern", $package.Class).invoke(null, "yyyyMMddHHmmssSSS"))}</functionAppName>
 #else


### PR DESCRIPTION
This pull request adds support for a new Azure Function trigger type, `McpToolTrigger`, and updates dependencies to their latest versions. The changes primarily focus on extending template support and ensuring correct configuration for the new trigger.

### New trigger support

* Added `McpToolTrigger` to the list of supported trigger types in the documentation (`README.md`) and templates (`archetype-post-generate.groovy`). This allows users to generate Azure Functions projects using this new trigger. [[1]](diffhunk://#diff-b8db0d8dbe8b30f27cada0ce9d3296a8897be1a0e993c22206961cb72ad8c893L59-R59) [[2]](diffhunk://#diff-eb61d586cda7639f428e45af1f8ec0a041f01fc21221e3c7ec305f0e00f2b5d3L48-R49)
* Introduced a new template mapping for `McpToolTrigger` in `archetype-post-generate.groovy`, specifying required parameters (`toolName`, `toolDescription`).

### Configuration updates

* Updated the `host.json` template to use a specific extension bundle version when the trigger is `McpToolTrigger`, ensuring compatibility.

### Dependency upgrades

* Bumped `azure.functions.maven.plugin.version` from `1.39.0` to `1.40.0` and `azure.functions.java.library.version` from `3.1.0` to `3.2.2` in `pom.xml` to use the latest Azure Functions tooling and libraries.